### PR TITLE
c_cpp_properties 的 defines 选项增加 '${default}' 参数

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -596,7 +596,7 @@ abstract class Target implements IView {
             configList.push({
                 name: this.cppConfigName,
                 includePath: Array.from(this.includes).concat(['${default}', '${workspaceFolder}/**']),
-                defines: Array.from(this.defines),
+                defines: Array.from(this.defines).concat('${default}'),
                 intelliSenseMode: '${default}'
             });
         } else {


### PR DESCRIPTION
因为部分宏定义存在需要在 vscode 中添加但不能在 keil 添加的情况，若 c_cpp_properties 的 defines 选项没有 '${default}' 参数，settings.json 中 C_Cpp.default.defines 定义的宏无法生效，导致代码很多地方提示错误，实际语法没有问题。